### PR TITLE
Bug fix for the EUV2 equation

### DIFF
--- a/Mors/physicalmodel.py
+++ b/Mors/physicalmodel.py
@@ -841,7 +841,7 @@ def _EUV2(StarState,params=params.paramsDefault):
   """Takes star state, returns Leuv2 in erg s^-1, Feuv2 in erg s^-1 cm^-1, and Reuv2 (36-92 nm)."""
   
   # Get Feuv2 from Feuv1 using equation from Johnstone et al. (2020)
-  Feuv2 = 10.0**( -0.341 + 0.92 * np.log10(StarState['Feuv1']) )
+  Feuv2 = 10.0**( -0.0341 + 0.92 * np.log10(StarState['Feuv1']) )
   
   # Get Leuv1 from this
   Leuv2 = Feuv2 * ( 4.0 * const.Pi * (StarState['Rstar']*const.Rsun)**2.0 )

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 
+NOTE: This version contains the fix for the error in the equation converting EUV1 to EUV2.
+
 -------------------------------------------------------------------------------------------------------------
 
 MODEL FOR ROTATION OF STARS (MORS)


### PR DESCRIPTION
The original version of the code had a wrong version of the equation for converting between EUV1 and EUV2 that massively underestimated EUV2. This version fixes it. I put a message at the top of the readme to highlight that this version should use the correct result.