### PR TITLE
fixed a bug in rotevo.py that broke AgesOut

### DIFF
--- a/Mors/rotevo.py
+++ b/Mors/rotevo.py
@@ -304,7 +304,7 @@ def _dAgeCalc(dAge,Age,AgeMax,AgesOut,params):
     else:
       
       # Get index of next age in AgesOut after current Age
-      index = SE._getIndexGT(AgesOut,Age)
+      index = misc._getIndexGT(AgesOut,Age)
       
       # Get new maximum age
       dAgeMax = AgesOut[index] - Age


### PR DESCRIPTION
Was trying to run Mors.Star for specific ages using AgesOut. The code broke on a line calling _getIndexGT from stellarevo.py rather than miscellaneous.py. This change fixed the code for me.